### PR TITLE
Implement channel_id command

### DIFF
--- a/youtool/cli.py
+++ b/youtool/cli.py
@@ -1,157 +1,35 @@
 import argparse
 import os
-import sys
+
+from commands import COMMANDS
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--api-key")
-    subparsers = parser.add_subparsers(required=True, dest="command")
+    """main docstring"""
+    parser = argparse.ArgumentParser(description="Youtube CLI Tool")
+    parser.add_argument("--api-key", type=str, help="YouTube API Key", dest="api_key")
+    subparsers = parser.add_subparsers(required=True, dest="command", title="Command", help="Comando a ser executado")
 
-    api_key = args.api_key or os.environ.get("YOUTUBE_API_KEY")
+    # cmd_channel_info = subparsers.add_parser("channel-info", help="Get channel info from a list of IDs (or CSV filename with IDs inside), generate CSV output (same schema for `channel` dicts)")
+    # cmd_video_info = subparsers.add_parser("video-info", help="Get video info from a list of IDs or URLs (or CSV filename with URLs/IDs inside), generate CSV output (same schema for `video` dicts)")
+    # cmd_video_search = subparsers.add_parser("video-search", help="Get video info from a list of IDs or URLs (or CSV filename with URLs/IDs inside), generate CSV output (simplified `video` dict schema or option to get full video info after)")
+    # cmd_video_comments = subparsers.add_parser("video-comments", help="Get comments from a video ID, generate CSV output (same schema for `comment` dicts)")
+    # cmd_video_livechat = subparsers.add_parser("video-livechat", help="Get comments from a video ID, generate CSV output (same schema for `chat_message` dicts)")
+    # cmd_video_transcriptions = subparsers.add_parser("video-transcription", help="Download video transcriptions based on language code, path and list of video IDs or URLs (or CSV filename with URLs/IDs inside), download files to destination and report results")
 
-    cmd_channel_id = subparsers.add_parser("channel-id", help="Get channel IDs from a list of URLs (or CSV filename with URLs inside), generate CSV output (just the IDs)")
-    cmd_channel_info = subparsers.add_parser("channel-info", help="Get channel info from a list of IDs (or CSV filename with IDs inside), generate CSV output (same schema for `channel` dicts)")
-    cmd_video_info = subparsers.add_parser("video-info", help="Get video info from a list of IDs or URLs (or CSV filename with URLs/IDs inside), generate CSV output (same schema for `video` dicts)")
-    cmd_video_search = subparsers.add_parser("video-search", help="Get video info from a list of IDs or URLs (or CSV filename with URLs/IDs inside), generate CSV output (simplified `video` dict schema or option to get full video info after)")
-    cmd_video_comments = subparsers.add_parser("video-comments", help="Get comments from a video ID, generate CSV output (same schema for `comment` dicts)")
-    cmd_video_livechat = subparsers.add_parser("video-livechat", help="Get comments from a video ID, generate CSV output (same schema for `chat_message` dicts)")
-    cmd_video_transcriptions = subparsers.add_parser("video-transcription", help="Download video transcriptions based on language code, path and list of video IDs or URLs (or CSV filename with URLs/IDs inside), download files to destination and report results")
+    for command in COMMANDS:
+        command.parse_arguments(subparsers)
 
     args = parser.parse_args()
+    args.api_key = args.api_key or os.environ.get("YOUTUBE_API_KEY")
 
-    if args.command == "channel-id":
-        print(f"Implement: {args.command}")  # TODO: implement
-
-    elif args.command == "channel-info":
-        print(f"Implement: {args.command}")  # TODO: implement
-
-    elif args.command == "video-info":
-        print(f"Implement: {args.command}")  # TODO: implement
-
-    elif args.command == "video-search":
-        print(f"Implement: {args.command}")  # TODO: implement
-        exit(1)
-
-        # TODO: update code below based on new YouTube class API
-        import rows
-        from loguru import logger
-        from tqdm import tqdm
-
-        from youtool import YouTube
-
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--key")
-        parser.add_argument("csv_filename")
-        parser.add_argument("url", nargs="+")
-        args = parser.parse_args()
-
-        key = args.key or os.environ.get("YOUTUBE_API_KEY")
-        if not key:
-            print("ERROR: Must provide an API key (--key or YOUTUBE_API_KEY env var)", file=sys.stderr)
-            exit(1)
-
-        if not Path(args.csv_filename).parent.exists():
-            Path(args.csv_filename).parent.mkdir(parents=True)
-        writer = rows.utils.CsvLazyDictWriter(args.csv_filename)  # TODO: use csv
-        yt = YouTube(key)
-        videos_urls = []
-        channels = {}
-        for url in tqdm(args.url, desc="Retrieving channel IDs"):
-            url = url.strip()
-            if "/watch?" in url:
-                videos_urls.append(url)
-                continue
-            channel_id = yt.channel_id_from_url(url)
-            if not channel_id:
-                username = url.split("youtube.com/")[1].split("?")[0].split("/")[0]
-                logger.warning(f"Channel ID not found for URL {url}")
-                continue
-            channels[channel_id] = {
-                "id": channel_id,
-                "url": url,
-            }
-        for channel_id, playlist_id in yt.playlists_ids(list(channels.keys())).items():
-            channels[channel_id]["playlist_id"] = playlist_id
-        fields = "id duration definition status views likes dislikes favorites comments channel_id title description published_at scheduled_to finished_at concurrent_viewers started_at".split()
-        # TODO: check fields
-        for data in tqdm(channels.values(), desc="Retrieving videos"):
-            try:
-                for video_batch in ipartition(yt.playlist_videos(data["playlist_id"]), 50):
-                    for video in yt.videos_infos([row["id"] for row in video_batch]):
-                        writer.writerow({field: video.get(field) for field in fields})
-            except RuntimeError:  # Cannot find playlist
-                continue
-        videos_ids = (video_url.split("watch?v=")[1].split("&")[0] for video_url in videos_urls)
-        for video in tqdm(yt.videos_infos(videos_ids), desc="Retrieving individual videos"):
-            writer.writerow({field: video.get(field) for field in fields})
-        writer.close()
-
-        # SEARCH
-        now = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
-        timezone_br = datetime.timezone(offset=datetime.timedelta(hours=-3))
-        now_br = now.astimezone(timezone_br)
-        search_start = (now - datetime.timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
-        search_stop = search_start + datetime.timedelta(hours=1)
-
-        parent = Path(__file__).parent
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--keys-filename", default=parent / "youtube-keys.csv")
-        parser.add_argument("--terms-filename", default=parent / "search-terms.csv")
-        parser.add_argument("--channels-filename", default=parent / "search-channels.csv")
-        parser.add_argument("--start", default=str(search_start))
-        parser.add_argument("--stop", default=str(search_stop))
-        parser.add_argument("--limit", type=int, default=20)
-        parser.add_argument("--order", default="viewCount")
-        parser.add_argument("data_path")
-        args = parser.parse_args()
-
-        data_path = Path(args.data_path)
-        keys_filename = Path(args.keys_filename)
-        terms_filename = Path(args.terms_filename)
-        channels_filename = Path(args.channels_filename)
-        now_path_name = now_br.strftime("%Y-%m-%dT%H")
-        youtube_keys = read_keys(keys_filename)
-        channels_groups = read_channels(args.channels_filename)
-        search_start, search_stop = args.start, args.stop
-        if isinstance(search_start, str):
-            search_start = datetime.datetime.fromisoformat(search_start)
-        if isinstance(search_stop, str):
-            search_stop = datetime.datetime.fromisoformat(search_stop)
-        search_start_str = search_start.astimezone(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        search_stop_str = search_stop.astimezone(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        search_limit = args.limit
-        search_order = args.order
-        terms_categories = read_csv_dictlist(terms_filename, "categoria", "termo")
-
-        print(search_start_str)
-        print(search_stop_str)
-
-        search_start_br = search_start.astimezone(timezone_br)
-        result_filename = data_path / f"search_{search_start_br.strftime('%Y-%m-%dT%H')}.csv"
-        writer = rows.utils.CsvLazyDictWriter(result_filename)
-        search_results = youtube_search(
-            terms_categories=terms_categories,
-            keys=youtube_keys["search"],
-            start=search_start_str,
-            stop=search_stop_str,
-            channels_groups=channels_groups,
-            order=search_order,
-            limit=search_limit,
-        )
-        for result in search_results:
-            writer.writerow(result)
-        writer.close()
-
-
-    elif args.command == "video-comments":
-        print(f"Implement: {args.command}")  # TODO: implement
-
-    elif args.command == "video-livechat":
-        print(f"Implement: {args.command}")  # TODO: implement
-
-    elif args.command == "video-transcription":
-        print(f"Implement: {args.command}")  # TODO: implement
+    if not args.api_key:
+        parser.error("YouTube API Key is required")
+    
+    try:
+        print(args.func(**args.__dict__))
+    except Exception as error:
+        parser.error(error)
 
 
 if __name__ == "__main__":

--- a/youtool/cli.py
+++ b/youtool/cli.py
@@ -5,10 +5,21 @@ from commands import COMMANDS
 
 
 def main():
-    """main docstring"""
-    parser = argparse.ArgumentParser(description="Youtube CLI Tool")
+    """
+    The main function for the CLI tool.
+
+    This function sets up the argument parser, including the API key and command-specific subparsers,
+    then parses the command-line arguments. It retrieves the YouTube API key from either the 
+    command-line argument or the environment variable 'YOUTUBE_API_KEY'. If the API key is not provided,
+    it raises an error. Finally, it executes the appropriate command based on the parsed arguments.
+
+    Raises:
+        argparse.ArgumentError: If the YouTube API key is not provided.
+        Exception: If there is an error during the execution of the command, it is caught and raised as an argparse error.
+    """
+    parser = argparse.ArgumentParser(description="CLI Tool for managing YouTube videos add playlists")
     parser.add_argument("--api-key", type=str, help="YouTube API Key", dest="api_key")
-    subparsers = parser.add_subparsers(required=True, dest="command", title="Command", help="Comando a ser executado")
+    subparsers = parser.add_subparsers(required=True, dest="command", title="Command", help="Command to be executed")
 
     # cmd_channel_info = subparsers.add_parser("channel-info", help="Get channel info from a list of IDs (or CSV filename with IDs inside), generate CSV output (same schema for `channel` dicts)")
     # cmd_video_info = subparsers.add_parser("video-info", help="Get video info from a list of IDs or URLs (or CSV filename with URLs/IDs inside), generate CSV output (same schema for `video` dicts)")

--- a/youtool/cli.py
+++ b/youtool/cli.py
@@ -6,22 +6,27 @@ from commands import COMMANDS
 
 def main():
     """
-    The main function for the CLI tool.
+    Main function for the YouTube CLI Tool.
 
-    This function sets up the argument parser, including the API key and command-specific subparsers,
-    then parses the command-line arguments. It retrieves the YouTube API key from either the 
-    command-line argument or the environment variable 'YOUTUBE_API_KEY'. If the API key is not provided,
-    it raises an error. Finally, it executes the appropriate command based on the parsed arguments.
+    This function sets up the argument parser for the CLI tool, including options for the YouTube API key and
+    command-specific subparsers. It then parses the command-line arguments, retrieving the YouTube API key
+    from either the command-line argument '--api-key' or the environment variable 'YOUTUBE_API_KEY'. If the API
+    key is not provided through any means, it raises an argparse.ArgumentError.
+
+    Finally, the function executes the appropriate command based on the parsed arguments. If an exception occurs
+    during the execution of the command, it is caught and raised as an argparse error for proper handling.
 
     Raises:
         argparse.ArgumentError: If the YouTube API key is not provided.
-        Exception: If there is an error during the execution of the command, it is caught and raised as an argparse error.
+        argparse.ArgumentError: If there is an error during the execution of the command.
+
     """
     parser = argparse.ArgumentParser(description="CLI Tool for managing YouTube videos add playlists")
     parser.add_argument("--api-key", type=str, help="YouTube API Key", dest="api_key")
+    parser.add_argument("--debug", type=bool, help="Debug mode", dest="debug")
+    
     subparsers = parser.add_subparsers(required=True, dest="command", title="Command", help="Command to be executed")
 
-    # cmd_channel_info = subparsers.add_parser("channel-info", help="Get channel info from a list of IDs (or CSV filename with IDs inside), generate CSV output (same schema for `channel` dicts)")
     # cmd_video_info = subparsers.add_parser("video-info", help="Get video info from a list of IDs or URLs (or CSV filename with URLs/IDs inside), generate CSV output (same schema for `video` dicts)")
     # cmd_video_search = subparsers.add_parser("video-search", help="Get video info from a list of IDs or URLs (or CSV filename with URLs/IDs inside), generate CSV output (simplified `video` dict schema or option to get full video info after)")
     # cmd_video_comments = subparsers.add_parser("video-comments", help="Get comments from a video ID, generate CSV output (same schema for `comment` dicts)")
@@ -40,7 +45,9 @@ def main():
     try:
         print(args.func(**args.__dict__))
     except Exception as error:
-        parser.error(error)
+        if args.debug:
+            raise error
+            parser.error(error)
 
 
 if __name__ == "__main__":

--- a/youtool/commands/__init__.py
+++ b/youtool/commands/__init__.py
@@ -1,0 +1,9 @@
+from .channel_id import ChannelId
+
+COMMANDS = [
+    ChannelId
+]
+
+__all__ = [
+    COMMANDS, ChannelId
+]

--- a/youtool/commands/__init__.py
+++ b/youtool/commands/__init__.py
@@ -1,9 +1,11 @@
 from .channel_id import ChannelId
+from .channel_info import ChannelInfo
 
 COMMANDS = [
-    ChannelId
+    ChannelId,
+    ChannelInfo
 ]
 
 __all__ = [
-    COMMANDS, ChannelId
+    COMMANDS, ChannelId, ChannelInfo
 ]

--- a/youtool/commands/base.py
+++ b/youtool/commands/base.py
@@ -1,0 +1,28 @@
+import argparse
+
+from typing import List, Dict, Any
+
+
+class Command():
+    """
+    classe para os comandos herdarem dela, obedecendo a estrutura
+    """
+    name: str
+    arguments: List[Dict[str, Any]]
+
+    @classmethod
+    def generate_parser(cls, subparsers: argparse._SubParsersAction):
+        return subparsers.add_parser(cls.name, help=cls.__doc__)
+
+    @classmethod
+    def parse_arguments(cls, subparsers: argparse._SubParsersAction) -> None:
+        parser = cls.generate_parser(subparsers)
+        for argument in cls.arguments:
+            argument_copy = {**argument}
+            argument_name = argument_copy.pop("name")
+            parser.add_argument(argument_name, **argument_copy)
+        parser.set_defaults(func=cls.execute)
+
+    @classmethod
+    def execute(cls, arguments: argparse.Namespace):
+        """método que vai executar o comando"""

--- a/youtool/commands/base.py
+++ b/youtool/commands/base.py
@@ -1,6 +1,10 @@
+import csv
 import argparse
 
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Self
+from io import StringIO
+from pathlib import Path
+from datetime import datetime
 
 
 class Command():
@@ -15,7 +19,7 @@ class Command():
     arguments: List[Dict[str, Any]]
 
     @classmethod
-    def generate_parser(cls, subparsers: argparse._SubParsersAction):
+    def generate_parser(cls: Self, subparsers: argparse._SubParsersAction):
         """
         Creates a parser for the command and adds it to the subparsers.
 
@@ -28,7 +32,7 @@ class Command():
         return subparsers.add_parser(cls.name, help=cls.__doc__)
 
     @classmethod
-    def parse_arguments(cls, subparsers: argparse._SubParsersAction) -> None:
+    def parse_arguments(cls: Self, subparsers: argparse._SubParsersAction) -> None:
         """
         Parses the arguments for the command and sets the command's execute method as the default function to call.
 
@@ -43,7 +47,7 @@ class Command():
         parser.set_defaults(func=cls.execute)
 
     @classmethod
-    def execute(cls, arguments: argparse.Namespace):
+    def execute(cls: Self, arguments: argparse.Namespace):
         """
         Executes the command.
 
@@ -52,3 +56,60 @@ class Command():
         Args:
             arguments (argparse.Namespace): The parsed arguments for the command.
         """
+        raise NotImplementedError()
+
+    @staticmethod
+    def data_from_csv(file_path: str, data_column_name: str = None) -> List[str]:
+        """
+        Extracts a list of URLs from a specified CSV file.
+
+        Args: file_path (str): The path to the CSV file containing the URLs.
+            data_column_name (str, optional): The name of the column in the CSV file that contains the URLs.
+                                            If not provided, it defaults to `ChannelId.URL_COLUMN_NAME`.
+
+        Returns:
+            List[str]: A list of URLs extracted from the specified CSV file.
+
+        Raises:
+            Exception: If the file path is invalid or the file cannot be found.
+        """
+        data = []
+
+        file_path = Path(file_path)
+        if not file_path.is_file():
+            raise FileNotFoundError(f"Invalid file path: {file_path}")
+
+        with file_path.open('r', newline='') as csv_file:
+            reader = csv.DictReader(csv_file)
+            if data_column_name not in reader.fieldnames:
+                raise Exception(f"Column {data_column_name} not found on {file_path}")
+            for row in reader:
+                data.append(row.get(data_column_name))
+        return data
+
+    @classmethod
+    def data_to_csv(cls: Self, data: List[Dict], output_file_path: str = None) -> str:
+        """
+        Converts a list of channel IDs into a CSV file.
+
+        Parameters:
+        channels_ids (List[str]): List of channel IDs to be written to the CSV.
+        output_file_path (str, optional): Path to the file where the CSV will be saved. If not provided, the CSV will be returned as a string.
+        channel_id_column_name (str, optional): Name of the column in the CSV that will contain the channel IDs. 
+                                                If not provided, the default value defined in ChannelId.CHANNEL_ID_COLUMN_NAME will be used.
+
+        Returns:
+        str: The path of the created CSV file or, if no path is provided, the contents of the CSV as a string.
+        """
+        if output_file_path:
+            output_path = Path(output_file_path)
+            if output_path.is_dir():
+                command_name = cls.name.replace("-", "_")
+                timestamp = datetime.now().strftime("%M%S%f")
+                output_file_path = output_path / f"{command_name}_{timestamp}.csv"
+
+        with (Path(output_file_path).open('w', newline='') if output_file_path else StringIO()) as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=list(data[0].keys()) if data else [])
+            writer.writeheader()
+            writer.writerows(data)
+            return str(output_file_path) if output_file_path else csv_file.getvalue()

--- a/youtool/commands/base.py
+++ b/youtool/commands/base.py
@@ -5,17 +5,36 @@ from typing import List, Dict, Any
 
 class Command():
     """
-    classe para os comandos herdarem dela, obedecendo a estrutura
+    A base class for commands to inherit from, following a specific structure.
+    
+    Attributes:
+        name (str): The name of the command.
+        arguments (List[Dict[str, Any]]): A list of dictionaries, each representing an argument for the command.
     """
     name: str
     arguments: List[Dict[str, Any]]
 
     @classmethod
     def generate_parser(cls, subparsers: argparse._SubParsersAction):
+        """
+        Creates a parser for the command and adds it to the subparsers.
+
+        Args:
+            subparsers (argparse._SubParsersAction): The subparsers action to add the parser to.
+
+        Returns:
+            argparse.ArgumentParser: The parser for the command.
+        """
         return subparsers.add_parser(cls.name, help=cls.__doc__)
 
     @classmethod
     def parse_arguments(cls, subparsers: argparse._SubParsersAction) -> None:
+        """
+        Parses the arguments for the command and sets the command's execute method as the default function to call.
+
+        Args:
+            subparsers (argparse._SubParsersAction): The subparsers action to add the parser to.
+        """
         parser = cls.generate_parser(subparsers)
         for argument in cls.arguments:
             argument_copy = {**argument}
@@ -25,4 +44,11 @@ class Command():
 
     @classmethod
     def execute(cls, arguments: argparse.Namespace):
-        """método que vai executar o comando"""
+        """
+        Executes the command.
+
+        This method should be overridden by subclasses to define the command's behavior.
+
+        Args:
+            arguments (argparse.Namespace): The parsed arguments for the command.
+        """

--- a/youtool/commands/channel_id.py
+++ b/youtool/commands/channel_id.py
@@ -1,0 +1,138 @@
+import os
+import csv
+
+from typing import List
+from datetime import datetime
+from io import StringIO
+
+from youtool import YouTube
+
+from .base import Command
+
+
+class ChannelId(Command):
+    """
+    Get channel IDs from a list of URLs (or CSV filename with URLs inside), generate CSV output (just the IDs)
+    """
+    name = "channel-id"
+    arguments = [
+        {"name": "--urls", "type": str, "help": "Channels urls", "nargs": "*"},
+        {"name": "--urls-file-path", "type": str, "help": "Channels urls csv file path"},
+        {"name": "--output-file-path", "type": str, "help": "Output csv file path"},
+        {"name": "--url-column-name", "type": str, "help": "URL column name on csv input files"},
+        {"name": "--id-column-name", "type": str, "help": "Channel ID column name on csv output files"}
+    ]
+
+    URL_COLUMN_NAME: str = "channel_url"
+    CHANNEL_ID_COLUMN_NAME: str = "channel_id"
+
+    @staticmethod
+    def urls_from_file(file_path: str, url_column_name: str = None) -> List[str]:
+        """
+        Extracts a list of URLs from a specified CSV file.
+
+        Args: file_path (str): The path to the CSV file containing the URLs.
+            url_column_name (str, optional): The name of the column in the CSV file that contains the URLs.
+                                            If not provided, it defaults to `ChannelId.URL_COLUMN_NAME`.
+
+        Returns:
+            List[str]: A list of URLs extracted from the specified CSV file.
+
+        Raises:
+            Exception: If the file path is invalid or the file cannot be found.
+        """
+        url_column_name = url_column_name or ChannelId.URL_COLUMN_NAME
+        urls = []
+
+        if not os.path.isfile(file_path):
+            raise Exception(f"Invalid file path: {file_path}")
+
+        with open(file_path, 'r', newline='') as csv_file:
+            reader = csv.DictReader(csv_file)
+            for row in reader:
+                urls.append(row.get(url_column_name))
+        return urls
+
+    @staticmethod
+    def ids_to_csv(channels_ids: List[str], output_file_path: str = None, channel_id_column_name: str = None) -> str:
+        """
+        Converts a list of channel IDs into a CSV file.
+
+        Parameters:
+        channels_ids (List[str]): List of channel IDs to be written to the CSV.
+        output_file_path (str, optional): Path to the file where the CSV will be saved. If not provided, the CSV will be returned as a string.
+        channel_id_column_name (str, optional): Name of the column in the CSV that will contain the channel IDs. 
+                                                If not provided, the default value defined in ChannelId.CHANNEL_ID_COLUMN_NAME will be used.
+
+        Returns:
+        str: The path of the created CSV file or, if no path is provided, the contents of the CSV as a string.
+        """
+        channel_id_column_name = channel_id_column_name or ChannelId.CHANNEL_ID_COLUMN_NAME
+
+        if output_file_path and os.path.isdir(output_file_path):
+            timestamp = datetime.now().strftime("%M%S%f")
+            output_file_path = os.path.join(output_file_path, f"channel_ids_{timestamp}.csv")
+
+        with (output_file_path and open(output_file_path, 'w', newline='') or StringIO()) as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=[channel_id_column_name])
+            writer.writeheader()
+            writer.writerows(
+                [{channel_id_column_name: channel_id} for channel_id in channels_ids]
+            )
+            return output_file_path or csv_file.getvalue()
+
+    @staticmethod
+    def execute(**kwargs) -> str:
+        """
+        Execute the channel-id command to fetch YouTube channel IDs from URLs and save them to a CSV file.
+
+        This method retrieves YouTube channel IDs from a list of provided URLs or from a file containing URLs.
+        It then saves these channel IDs to a CSV file if an output file path is specified.
+
+        Args:
+            urls (list[str], optional): A list of YouTube channel URLs. If not provided, `urls_file_path` must be specified.
+            urls_file_path (str, optional): Path to a CSV file containing YouTube channel URLs. 
+                                            The file should contain a column with URLs, specified by `url_column_name`.
+            output_file_path (str, optional): Path to the output CSV file where channel IDs will be saved.
+                                            If not provided, the result will be returned as a string.
+            api_key (str): The API key to authenticate with the YouTube Data API.
+            url_column_name (str, optional): The name of the column in the `urls_file_path` CSV file that contains the URLs.
+                                            Default is "url".
+            id_column_name (str, optional): The name of the column for channel IDs in the output CSV file.
+                                            Default is "channel_id".
+
+        Returns:
+            str: A message indicating the result of the command. If `output_file_path` is specified, the message will
+                include the path to the generated CSV file. Otherwise, it will return the result as a string.
+
+        Raises:
+            Exception: If neither `urls` nor `urls_file_path` is provided.
+        """
+        urls = kwargs.get("urls")
+        urls_file_path = kwargs.get("urls_file_path")
+        output_file_path = kwargs.get("output_file_path")
+        api_key = kwargs.get("api_key")
+
+        url_column_name = kwargs.get("url_column_name")
+        id_column_name = kwargs.get("id_column_name")
+
+        urls = urls or ChannelId.urls_from_file(urls_file_path, url_column_name)
+
+        if not urls:
+            raise Exception("username or url required on channel-id command")
+
+        youtube = YouTube([api_key], disable_ipv6=True)
+
+        channels_ids = [
+            youtube.channel_id_from_url(url) for url in urls
+        ]
+
+        result = ChannelId.ids_to_csv(
+            channels_ids=channels_ids,
+            output_file_path=output_file_path,
+            channel_id_column_name=id_column_name
+        )
+
+        if output_file_path:
+            return f"CSV File with channels ids generated: {result}"
+        return result

--- a/youtool/commands/channel_info.py
+++ b/youtool/commands/channel_info.py
@@ -1,0 +1,120 @@
+import csv
+
+from typing import List, Dict, Optional, Self
+
+from youtool import YouTube
+
+from .base import Command
+
+
+class ChannelInfo(Command):
+    """
+    Get channel info from a list of IDs (or CSV filename with IDs inside), generate CSV output 
+    (same schema for `channel` dicts)
+    """
+    name = "channel-info"
+    arguments = [
+        {"name": "--urls", "type": str, "help": "Channel URLs", "nargs": "*"},
+        {"name": "--usernames", "type": str, "help": "Channel usernames", "nargs": "*"},
+        {"name": "--ids", "type": str, "help": "Channel IDs", "nargs": "*"},
+        {"name": "--urls-file-path", "type": str, "help": "Channel URLs CSV file path"},
+        {"name": "--usernames-file-path", "type": str, "help": "Channel usernames CSV file path"},
+        {"name": "--ids-file-path", "type": str, "help": "Channel IDs CSV file path"},
+        {"name": "--output-file-path", "type": str, "help": "Output CSV file path"},
+        {"name": "--url-column-name", "type": str, "help": "URL column name on CSV input files"},
+        {"name": "--username-column-name", "type": str, "help": "Username column name on CSV input files"},
+        {"name": "--id-column-name", "type": str, "help": "ID column name on CSV input files"},
+    ]
+
+    URL_COLUMN_NAME: str = "channel_url"
+    USERNAME_COLUMN_NAME: str = "channel_username"
+    ID_COLUMN_NAME: str = "channel_id"
+    INFO_COLUMNS: List[str] = [
+        "id", "title", "description", "published_at", "view_count", "subscriber_count", "video_count"
+    ]
+
+    @staticmethod
+    def filter_fields(channel_info: Dict, info_columns: Optional[List] = None):
+        """
+        Filters the fields of a dictionary containing channel information based on 
+        specified columns.
+
+        Args:
+            channel_info (Dict): A dictionary containing channel information.
+            info_columns (Optional[List], optional): A list specifying which fields 
+                to include in the filtered output. If None, returns the entire 
+                channel_info dictionary. Defaults to None.
+
+        Returns:
+            Dict: A dictionary containing only the fields specified in info_columns 
+                (if provided) or the entire channel_info dictionary if info_columns is None.
+        """
+        return {
+            field: value for field, value in channel_info.items() if field in info_columns
+        } if info_columns else channel_info
+
+    @classmethod
+    def execute(cls: Self, **kwargs) -> str:
+        """
+        Execute the channel-info command to fetch YouTube channel information from URLs or usernames and save them to a CSV file.
+
+        Args:
+            urls (list[str], optional): A list of YouTube channel URLs. If not provided, `urls_file_path` must be specified.
+            usernames (list[str], optional): A list of YouTube channel usernames. If not provided, `usernames_file_path` must be specified.
+            urls_file_path (str, optional): Path to a CSV file containing YouTube channel URLs.
+            usernames_file_path (str, optional): Path to a CSV file containing YouTube channel usernames.
+            output_file_path (str, optional): Path to the output CSV file where channel information will be saved.
+            api_key (str): The API key to authenticate with the YouTube Data API.
+            url_column_name (str, optional): The name of the column in the `urls_file_path` CSV file that contains the URLs.
+                                            Default is "channel_url".
+            username_column_name (str, optional): The name of the column in the `usernames_file_path` CSV file that contains the usernames.
+                                            Default is "channel_username".
+            info_columns (str, optional): Comma-separated list of columns to include in the output CSV. Default is the class attribute `INFO_COLUMNS`.
+
+        Returns:
+            str: A message indicating the result of the command. If `output_file_path` is specified, the message will
+                include the path to the generated CSV file. Otherwise, it will return the result as a string.
+
+        Raises:
+            Exception: If neither `urls`, `usernames`, `urls_file_path` nor `usernames_file_path` is provided.
+        """
+        urls = kwargs.get("urls")
+        usernames = kwargs.get("usernames")
+        urls_file_path = kwargs.get("urls_file_path")
+        usernames_file_path = kwargs.get("usernames_file_path")
+        output_file_path = kwargs.get("output_file_path")
+        api_key = kwargs.get("api_key")
+
+        url_column_name = kwargs.get("url_column_name")
+        username_column_name = kwargs.get("username_column_name")
+        info_columns = kwargs.get("info_columns")
+
+        info_columns = [
+            column.strip() for column in info_columns.split(",")
+        ] if info_columns else ChannelInfo.INFO_COLUMNS
+
+        if urls_file_path and not urls:
+            urls = ChannelInfo.data_from_file(urls_file_path, url_column_name)
+        if usernames_file_path and not usernames:
+            usernames = ChannelInfo.data_from_file(usernames_file_path, username_column_name)
+
+        if not urls and not usernames:
+            raise Exception("Either 'urls' or 'usernames' must be provided for the channel-info command")
+
+        youtube = YouTube([api_key], disable_ipv6=True)
+
+        channels_ids = [
+            youtube.channel_id_from_url(url) for url in (urls or []) if url
+        ] + [
+            youtube.channel_id_from_username(username) for username in (usernames or []) if username
+        ]
+        channel_ids = [channel_id for channel_id in channels_ids if channel_id]
+
+        return cls.data_to_csv(
+            data=[
+                ChannelInfo.filter_fields(
+                    channel_info, info_columns
+                ) for channel_info in (youtube.channels_infos(channel_ids) or [])
+            ],
+            output_file_path=output_file_path
+        )


### PR DESCRIPTION
## Add command to extract youtube channel IDs from URLs and generate CSV

### Overview

This PR introduces a new command, `ChannelId`, which extracts youtube channel IDs from a list of URLs or from a CSV file containing URLs and generates a CSV file with the channel IDs.

### Features

- **Command Implementation**: `ChannelId` command to handle the extraction of youtube channel IDs.
- **Command execution**: Enhanced `execute` method to handle the end-to-end process of fetching channel IDs and generating the output CSV.
- **Command Base Class**: Implemented `Command` as a foundational class for defining CLI commands.
- **Default Execution Method**: Introduced `parse_arguments` method to configure argument parsing and set `execute` method as the default action for each command.
- **Extendable Execution Logic**: Included an abstract `execute` method, to be overridden by subclasses, for executing command-specific logic.

### Usage

To use the new `ChannelId` command:

1. **From a list of URLs:**
   ```sh
   python cli.py --api_key <api_key> channel-id --urls <url1> <url2> --output-file-path <output_path>
   ``` 
  
2. **These are other ways to run the ChannelId command:**
- The command was designed to extract the YouTube channel ID associated with a provided URL.
```
   python cli.py --api-key <api_key> channel-id --urls <url1>
```
- The command is used to perform automated extraction of YouTube channel IDs from URLs contained in a CSV file.
```
   python cli.py --api-key <api_key> channel-id --urls-file-path <input_csv_path>
```



